### PR TITLE
Add Enron email extraction scripts and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# COS70008 - Enron Email Extraction  
+
+This repository contains the scripts and notebooks for extracting and processing the Enron email dataset.  
+
+## Important
+- **Large dataset files are NOT in GitHub.**  
+- All big files (e.g. `Emails.parquet`, `.tar.gz`, `.xlsx`) are stored in our shared **OneDrive** folder.  
+
+## Files in this repo
+- `extract_emails.py`: Script to parse and convert the raw dataset into structured format.  
+- `untar_fix.py`: Helper script to unpack `.tar.gz` files.  
+- `README.md`: Project overview and usage notes.  
+
+## How to use
+1. Clone this repo.  
+2. Download the dataset files from OneDrive.  
+3. Place them in the project folder.  
+4. Run the scripts (e.g., `extract_emails.py`) as needed.  

--- a/extract_emails.py
+++ b/extract_emails.py
@@ -1,0 +1,103 @@
+# extract_emails.py
+import os, hashlib
+import pandas as pd
+from email import policy
+from email.parser import BytesParser
+from email.utils import parsedate_to_datetime
+from datetime import timezone
+
+DATA_DIR = "maildir_fixed"      # <- cleaned tree
+OUTPUT   = "Emails.parquet"
+LIMIT    = None              # set to None for full run after testing
+
+def parse_list(field: str):
+    if not field:
+        return []
+    parts = []
+    for chunk in field.replace("\n", " ").split(","):
+        parts.extend([p.strip().lower() for p in chunk.split(";") if p.strip()])
+    return parts
+
+def parse_dt_utc(date_str: str):
+    if not date_str:
+        return None
+    try:
+        dt = parsedate_to_datetime(date_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+    except Exception:
+        return None
+
+def owner_from_root(root: str):
+    # work for both "maildir" and "maildir_fixed"
+    parts = os.path.normpath(root).split(os.sep)
+    for anchor in ("maildir_fixed", "maildir"):
+        if anchor in parts:
+            i = parts.index(anchor)
+            if i + 1 < len(parts):
+                return parts[i + 1]
+    return None
+
+rows, ok, skip = [], 0, 0
+
+if not os.path.isdir(DATA_DIR):
+    raise SystemExit(f"DATA_DIR not found: {DATA_DIR}")
+
+for root, _, files in os.walk(DATA_DIR):
+    folder = os.path.basename(root).lower()
+    owner  = owner_from_root(root)
+
+    for fname in files:
+        path = os.path.join(root, fname)
+
+        # open file normally (names are cleaned now)
+        try:
+            with open(path, "rb") as fp:
+                msg = BytesParser(policy=policy.default).parse(fp)
+        except Exception:
+            skip += 1
+            continue
+
+        try:
+            part = msg.get_body(preferencelist=("plain", "html"))
+            body = part.get_content() if part else msg.get_content()
+
+            rec = {
+                "email_id": hashlib.md5((os.path.abspath(path) + str(msg.get("Message-ID"))).encode("utf-8")).hexdigest(),
+                "msg_id": msg.get("Message-ID"),
+                "from_raw": (msg.get("From") or "").lower(),
+                "to_list": parse_list(msg.get("To")),
+                "cc_list": parse_list(msg.get("Cc")),
+                "bcc_list": parse_list(msg.get("Bcc")),
+                "dt_utc": parse_dt_utc(msg.get("Date")),
+                "subject": msg.get("Subject"),
+                "body_raw": body,
+                "employee_dir": owner,
+                "folder": folder,
+                "path": os.path.abspath(path),
+            }
+            rows.append(rec)
+            ok += 1
+            if ok % 5000 == 0:
+                print(f"Parsed {ok} emails… (skipped {skip})")
+            if LIMIT and ok >= LIMIT:
+                break
+        except Exception:
+            skip += 1
+            continue
+    if LIMIT and ok >= LIMIT:
+        break
+
+print(f"Finished: parsed={ok}, skipped={skip}")
+
+# ---- Save to Parquet ----
+df = pd.DataFrame(rows)
+cols = ["email_id","msg_id","from_raw","to_list","cc_list","bcc_list",
+        "dt_utc","subject","body_raw","employee_dir","folder","path"]
+for c in cols:
+    if c not in df.columns:
+        df[c] = None
+df = df[cols]
+df.to_parquet(OUTPUT, index=False)
+print(f"Saved {len(df)} emails -> {OUTPUT}")

--- a/untar_fix.py
+++ b/untar_fix.py
@@ -1,0 +1,55 @@
+# untar_fix_windows.py
+import tarfile, os, shutil, re
+
+SRC = "enron_mail_20150507.tar.gz"
+DST = "maildir_fixed"  # new, cleaned output
+
+def sanitize(path: str) -> str:
+    # normalize slashes and remove leading "./"
+    path = path.replace("\\", "/")
+    if path.startswith("./"):
+        path = path[2:]
+    # only keep the maildir subtree
+    # the archive stores paths like "maildir/allen-p/_sent_mail/1."
+    # strip trailing dots/spaces on every path segment (Windows can't handle them)
+    parts = []
+    for seg in path.split("/"):
+        if seg in ("", ".", ".."):
+            continue
+        seg = re.sub(r"[\. ]+$", "", seg)  # remove trailing dots/spaces
+        parts.append(seg)
+    return os.path.join(*parts) if parts else ""
+
+# clean target if it exists
+if os.path.isdir(DST):
+    shutil.rmtree(DST)
+os.makedirs(DST, exist_ok=True)
+
+count = 0
+with tarfile.open(SRC, "r:gz") as tf:
+    for m in tf.getmembers():
+        if not m.name.startswith("maildir/"):
+            continue
+        clean_rel = sanitize(m.name)
+        if not clean_rel:
+            continue
+        out_path = os.path.join(DST, clean_rel)
+
+        if m.isdir():
+            os.makedirs(out_path, exist_ok=True)
+            continue
+
+        # ensure parent dir exists
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+        # extract file content safely
+        f = tf.extractfile(m)
+        if f is None:
+            continue
+        with open(out_path, "wb") as w:
+            w.write(f.read())
+        count += 1
+        if count % 10000 == 0:
+            print(f"Extracted {count} files...")
+
+print(f"Done. Extracted {count} files into {DST}")


### PR DESCRIPTION
- Added extract_emails.py to parse and convert Enron dataset into Parquet format
- Added untar_fix.py to handle .tar.gz extraction
- Updated README.md with project overview and usage instructions
